### PR TITLE
Proposal to use regex to identify an integer to identify template id …

### DIFF
--- a/src/Postmark/PostmarkClient.php
+++ b/src/Postmark/PostmarkClient.php
@@ -117,7 +117,7 @@ class PostmarkClient extends PostmarkClientBase {
 			$body['TrackLinks'] = $trackLinks;
 		}
 
-		if ( is_int( $templateIdOrAlias ) ) {
+		if ( preg_match('/^\d+$/', $templateIdOrAlias) === 1) {
 			$body['TemplateId'] = $templateIdOrAlias;
 
 			// Uses the Template Alias if specified instead of Template ID.


### PR DESCRIPTION
…instead of is_int(). PHP type coersion together with weak typing can have the unintended consequence of causing the template id to be a string according to is_int(). I believe as was my case that many template ids in the wild will be unrecognized as a template alias because it was identified as a string. Besides this, a template alias cannot begin with a number.