### PR TITLE
Update DynamicResponseModel.php

### DIFF
--- a/src/Postmark/Models/DynamicResponseModel.php
+++ b/src/Postmark/Models/DynamicResponseModel.php
@@ -53,7 +53,7 @@ class DynamicResponseModel extends CaseInsensitiveArray {
 	/**
 	 * Infrastructure. Allows indexer to return a DynamicResponseModel.
 	 */
-	public function offsetGet($offset) {
+	public function offsetGet(mixed $offset): mixed {
 		$result = parent::offsetGet($offset);
 		if ($result != NULL && is_array($result)) {
 			$result = new DynamicResponseModel($result);
@@ -62,4 +62,4 @@ class DynamicResponseModel extends CaseInsensitiveArray {
 	}
 }
 
-?>
+#EOF#


### PR DESCRIPTION
In PHP 8.0.13+ and 8.1 error:
```
Fatal error: Declaration of Postmark\Models\DynamicResponseModel::offsetGet($offset) must be compatible with Postmark\Models\CaseInsensitiveArray::offsetGet(mixed $offset): mixed in vendor/wildbit/postmark-php/src/Postmark/Models/DynamicResponseModel.php on line 56
```