### PR TITLE
Suppress (more) PHP 8.1 warnings

### DIFF
--- a/src/Postmark/Models/Suppressions/SuppressionChangeRequest.php
+++ b/src/Postmark/Models/Suppressions/SuppressionChangeRequest.php
@@ -17,6 +17,7 @@ class SuppressionChangeRequest implements \JsonSerializable {
         $this->emailAddress = $emailAddress;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize() {
         $retval = array(
             "EmailAddress" => $this->emailAddress


### PR DESCRIPTION
Temporarily suppresses the PHP 8.1 warning:

`Return type of Postmark\Models\Suppressions\SuppressionChangeRequest::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`