### PR TITLE
Update default timeout to be consistent with other libraries

### DIFF
--- a/src/Postmark/PostmarkAdminClient.php
+++ b/src/Postmark/PostmarkAdminClient.php
@@ -21,7 +21,7 @@ class PostmarkAdminClient extends PostmarkClientBase {
 	 *
 	 * @param integer $timeout The timeout, in seconds, that API calls should wait before throwing an exception.
 	 */
-	function __construct($accountToken, $timeout = 30) {
+	function __construct($accountToken, $timeout = 60) {
 		parent::__construct($accountToken, "X-Postmark-Account-Token", $timeout);
 	}
 

--- a/src/Postmark/PostmarkClient.php
+++ b/src/Postmark/PostmarkClient.php
@@ -19,7 +19,7 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param string $serverToken The token associated with "Server" you'd like to use to send/receive email from.
 	 * @param integer $timeout The timeout, in seconds to wait for an API call to complete before throwing an Exception.
 	 */
-	function __construct($serverToken, $timeout = 30) {
+	function __construct($serverToken, $timeout = 60) {
 		parent::__construct($serverToken, 'X-Postmark-Server-Token', $timeout);
 	}
 

--- a/src/Postmark/PostmarkClientBase.php
+++ b/src/Postmark/PostmarkClientBase.php
@@ -47,12 +47,12 @@ abstract class PostmarkClientBase {
 	protected $authorization_header = NULL;
 	protected $version = NULL;
 	protected $os = NULL;
-	protected $timeout = 30;
+	protected $timeout = 60;
 
 	/** @var  Client */
 	protected $client;
 
-	protected function __construct($token, $header, $timeout = 30) {
+	protected function __construct($token, $header, $timeout = 60) {
 		$this->authorization_header = $header;
 		$this->authorization_token = $token;
 		$this->version = phpversion();


### PR DESCRIPTION
## What

Updates timeout to 60s to be consistent with https://github.com/ActiveCampaign/postmark-gem/pull/133 and others.

## How

Looks like there are some opportunities for DRYing up this configuration, but for now this is just a straight search/replace.