### PR TITLE
Fix response object for Send email with template request

### DIFF
--- a/src/Postmark/Models/Templates/SendEmailWithTemplateResponse.php
+++ b/src/Postmark/Models/Templates/SendEmailWithTemplateResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Postmark\Models\Templates;
+
+use Postmark\Models\PostmarkResponse;
+
+final class SendEmailWithTemplateResponse extends PostmarkResponse
+{
+    private string $Recipient;
+    private string $SubmittedAt;
+    private string $MessageID;
+
+    public function __construct(array $values)
+    {
+        parent::__construct($values);
+
+        $this->Recipient = !empty($values['To']) ? $values['To'] : "";
+        $this->SubmittedAt = !empty($values['SubmittedAt']) ? $values['SubmittedAt'] : "";
+        $this->MessageID = !empty($values['MessageID']) ? $values['MessageID'] : "";
+    }
+
+    public function getRecipient(): string
+    {
+        return $this->Recipient;
+    }
+
+    public function getSubmittedAt(): string
+    {
+        return $this->SubmittedAt;
+    }
+
+    public function getMessageID(): string
+    {
+        return $this->MessageID;
+    }
+}

--- a/src/Postmark/PostmarkClient.php
+++ b/src/Postmark/PostmarkClient.php
@@ -3,6 +3,7 @@
 namespace Postmark;
 
 use Postmark\Models\DynamicResponseModel as DynamicResponseModel;
+use Postmark\Models\Templates\SendEmailWithTemplateResponse;
 use Postmark\PostmarkClientBase as PostmarkClientBase;
 use Postmark\Models\PostmarkBounce;
 use Postmark\Models\PostmarkBounceActivation;
@@ -132,7 +133,7 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param string|null $trackLinks  Can be any of "None", "HtmlAndText", "HtmlOnly", "TextOnly" to enable link tracking.
 	 * @param array|null $metadata  Add metadata to the message. The metadata is an associative array , and values will be evaluated as strings by Postmark.
 	 * @param array|null $messageStream  The message stream used to send this message. If not provided, the default transactional stream "outbound" will be used.
-	 * @return PostmarkResponse
+	 * @return SendEmailWithTemplateResponse
 	 */
 	function sendEmailWithTemplate(
         string     $from,
@@ -149,7 +150,7 @@ class PostmarkClient extends PostmarkClientBase {
         array  $attachments = NULL,
         string $trackLinks = NULL,
         array  $metadata = NULL,
-        array  $messageStream = NULL): PostmarkResponse
+        array  $messageStream = NULL): SendEmailWithTemplateResponse
     {
 		$body = array();
 		$body['From'] = $from;
@@ -181,7 +182,7 @@ class PostmarkClient extends PostmarkClientBase {
 			$body['TemplateAlias'] = $templateIdOrAlias;
 		}
 
-		return new PostmarkResponse((array)$this->processRestRequest('POST', '/email/withTemplate', $body));
+		return new SendEmailWithTemplateResponse((array)$this->processRestRequest('POST', '/email/withTemplate', $body));
 	}
 
 	/**

--- a/tests/PostmarkClientTemplatesTest.php
+++ b/tests/PostmarkClientTemplatesTest.php
@@ -145,7 +145,11 @@ class PostmarkClientTemplatesTest extends PostmarkClientBaseTest {
 		$emailResult = $client->sendEmailWithTemplate($tk->WRITE_TEST_SENDER_EMAIL_ADDRESS,
 			$tk->WRITE_TEST_EMAIL_RECIPIENT_ADDRESS, $result->getTemplateId(), array("subjectValue" => "Hello!"));
 
-		$this->assertEquals(0, $emailResult->getErrorCode());
+		self::assertSame(0, $emailResult->getErrorCode());
+        self::assertSame('OK', $emailResult->getMessage());
+        self::assertSame($tk->WRITE_TEST_EMAIL_RECIPIENT_ADDRESS, $emailResult->getRecipient());
+        self::assertNotEmpty($emailResult->getSubmittedAt());
+        self::assertNotEmpty($emailResult->getMessageID());
 	}
 	
 	//send batch


### PR DESCRIPTION
After adding return data objects instead of Dynamic response model, we lost access to MessageID from response - 

https://postmarkapp.com/developer/api/templates-api#email-with-template