### PR TITLE
Fix fatal error when headers is null

### DIFF
--- a/src/Postmark/Models/PostmarkMessageBase.php
+++ b/src/Postmark/Models/PostmarkMessageBase.php
@@ -134,7 +134,7 @@ class PostmarkMessageBase
         return $this->Headers;
     }
 
-    public function setHeaders(array $Headers): PostmarkMessageBase
+    public function setHeaders(?array $Headers): PostmarkMessageBase
     {
         $this->Headers = $Headers;
 


### PR DESCRIPTION
Headers defaults to "null" if empty, and "fixHeaders" can return null too. Then we should allow "null" for the setHeaders function.