### PR TITLE
Adds PHP 8.4 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ workflows:
           version: "8.3"
           requires:
             - php82
+      - unit-tests:
+          name: php84
+          version: "8.4"
+          requires:
+            - php83
 
 jobs:
   unit-tests:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "description": "The officially supported client for Postmark (http://postmarkapp.com)",
   "require": {
-    "php": "~8.1 || ~8.2|| ~8.3",
+    "php": "~8.1 || ~8.2|| ~8.3 || ~8.4",
     "guzzlehttp/guzzle": "^7.8"
   },
   "require-dev": {

--- a/src/Postmark/PostmarkClient.php
+++ b/src/Postmark/PostmarkClient.php
@@ -1339,7 +1339,7 @@ class PostmarkClient extends PostmarkClientBase
      *
      * @throws PostmarkException
      */
-    public function getWebhookConfigurations(string $messageStream = null): WebhookConfigurationListingResponse
+    public function getWebhookConfigurations(?string $messageStream = null): WebhookConfigurationListingResponse
     {
         $query = [];
         $query['MessageStream'] = $messageStream;
@@ -1424,7 +1424,7 @@ class PostmarkClient extends PostmarkClientBase
      *
      * @throws PostmarkException
      */
-    public function createSuppressions(array $suppressionChanges = [], string $messageStream = null): PostmarkSuppressionResultList
+    public function createSuppressions(array $suppressionChanges = [], ?string $messageStream = null): PostmarkSuppressionResultList
     {
         $body = [];
         $body['Suppressions'] = $suppressionChanges;
@@ -1522,7 +1522,7 @@ class PostmarkClient extends PostmarkClientBase
      *
      * @throws PostmarkException
      */
-    public function editMessageStream(string $id, string $name = null, ?string $description = null): PostmarkMessageStream
+    public function editMessageStream(string $id, ?string $name = null, ?string $description = null): PostmarkMessageStream
     {
         $body = [];
         $body['Name'] = $name;


### PR DESCRIPTION
This adds PHP8.4 support:

- Adding to composer.json
- Making sure tests run in 8.4 (cannot test it but looks straight forward enough)
- Adding explicit 8.4 support (although technically ~8.3 already supports 8.4): https://getcomposer.org/doc/articles/versions.md#tilde-version-range-


Please merge this :) 