### PR TITLE
Allow Guzzle 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "description": "The officially supported client for Postmark (https://postmarkapp.com)",
   "require": {
     "php": "~8.1 || ~8.2|| ~8.3 || ~8.4",
-    "guzzlehttp/guzzle": "^7.8"
+    "guzzlehttp/guzzle": "^7.8 || ^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.0",


### PR DESCRIPTION
## Summary

Allow Guzzle 8 alongside the existing Guzzle 7.8 constraint. The current client usage relies on APIs shared by both supported major versions.